### PR TITLE
Feature tailoring for zinc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ spec/dummy/tmp/
 spec/dummy/.sass-cache
 Gemfile.lock
 .DS_Store
+.tags*
+.byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -11,4 +11,4 @@ gemspec
 # your gem to rubygems.org.
 
 # To use a debugger
-# gem 'byebug', group: [:development, :test]
+gem 'byebug', group: [:development, :test]

--- a/app/models/concerns/wupee/receiver.rb
+++ b/app/models/concerns/wupee/receiver.rb
@@ -7,8 +7,9 @@ module Wupee
       has_many :notification_type_configurations, as: :receiver, dependent: :destroy, class_name: "Wupee::NotificationTypeConfiguration"
 
       after_create do
-        Wupee::NotificationType.pluck(:id).each do |notification_type_id|
-          Wupee::NotificationTypeConfiguration.create!(notification_type_id: notification_type_id, receiver: self)
+        Wupee::NotificationType.select([:id, :name]).each do |notification|
+          value = Wupee::NotificationTypeConfiguration.get_config_for(self.class.to_s, notification.name)
+          Wupee::NotificationTypeConfiguration.create!(notification_type_id: notification.id, receiver: self, value: value)
         end
       end
     end

--- a/app/models/wupee/notification_type.rb
+++ b/app/models/wupee/notification_type.rb
@@ -10,8 +10,8 @@ class Wupee::NotificationType < ActiveRecord::Base
       receivers.each do |receiver|
         after_create do
           value = Wupee::NotificationTypeConfiguration.get_config_for(receiver, self.name)
-          receiver.to_s.constantize.pluck(:id).each do |receiver_id|
-            Wupee::NotificationTypeConfiguration.create!(notification_type: self, receiver_type: receiver, receiver_id: receiver_id, value: value)
+          receiver.to_s.constantize.select(:id).find_each(batch_size: 5000) do |obj|
+            Wupee::NotificationTypeConfiguration.create!(notification_type: self, receiver_type: receiver, receiver_id: obj.id, value: value)
           end
         end
       end

--- a/app/models/wupee/notification_type.rb
+++ b/app/models/wupee/notification_type.rb
@@ -9,8 +9,9 @@ class Wupee::NotificationType < ActiveRecord::Base
     class_eval do
       receivers.each do |receiver|
         after_create do
+          value = Wupee::NotificationTypeConfiguration.get_config_for(receiver, self.name)
           receiver.to_s.constantize.pluck(:id).each do |receiver_id|
-            Wupee::NotificationTypeConfiguration.create!(notification_type: self, receiver_type: receiver, receiver_id: receiver_id)
+            Wupee::NotificationTypeConfiguration.create!(notification_type: self, receiver_type: receiver, receiver_id: receiver_id, value: value)
           end
         end
       end

--- a/app/models/wupee/notification_type_configuration.rb
+++ b/app/models/wupee/notification_type_configuration.rb
@@ -7,6 +7,23 @@ class Wupee::NotificationTypeConfiguration < ActiveRecord::Base
 
   enum value: { both: 0, nothing: 1, email: 2, notification: 3 }
 
+  DEFAULT_VALUE = 'both'
+
+
+  def self.set_default_config(config = {})
+    @@config = config
+  end
+
+  def self.get_default_config
+    @@config ||= {}
+  end
+
+  def self.get_config_for(receiver, notification_name)
+    receiver_config = get_default_config[receiver]
+    return DEFAULT_VALUE unless receiver_config
+    receiver_config[notification_name] || DEFAULT_VALUE
+  end
+
   def wants_email?
     ['both', 'email'].include?(value)
   end

--- a/spec/models/concerns/receiver_spec.rb
+++ b/spec/models/concerns/receiver_spec.rb
@@ -33,5 +33,19 @@ shared_examples_for "Wupee::Receiver" do
       expect { create model.name.underscore }.to change { Wupee::NotificationTypeConfiguration.count }.by(1)
       expect(Wupee::NotificationTypeConfiguration.last.receiver).to eq model.last
     end
+
+    it "creates configuration with default config's value" do
+      default_config = {
+        'User' => {
+          'signed_in' => 'notification'
+        }
+      }
+      Wupee::NotificationTypeConfiguration.set_default_config default_config
+      create :notification_type, name: 'signed_in'
+      expect { create model.name.underscore }.to change { Wupee::NotificationTypeConfiguration.count }.by(1)
+      created_configuration = Wupee::NotificationTypeConfiguration.last
+      expect(created_configuration.value).to eq('notification')
+    end
   end
+
 end

--- a/spec/models/notification_type_spec.rb
+++ b/spec/models/notification_type_spec.rb
@@ -31,9 +31,26 @@ RSpec.describe Wupee::NotificationType, type: :model do
   end
 
   context "class methods" do
-    it "has a method create_configurations_for which creates NotificationTypeConfiguration objects" do
-      expect { create :notification_type, name: "random_notif_type_2" }.to change { Wupee::NotificationTypeConfiguration.count }.by(User.count)
+    context 'has a method create_configurations_for' do
+
+      it "which creates NotificationTypeConfiguration objects" do
+        expect { create :notification_type, name: "random_notif_type_2" }.to change { Wupee::NotificationTypeConfiguration.count }.by(User.count)
+      end
+
+      it 'creates configuration objects with default configs value' do
+        expect(User.count).to eq(1)
+        default_config = {
+          'User' => {
+            'signed_in' => 'notification'
+          }
+        }
+        Wupee::NotificationTypeConfiguration.set_default_config default_config
+        create :notification_type, name: "signed_in"
+        expect(Wupee::NotificationTypeConfiguration.last.value).to eq('notification')
+      end
     end
+
+
   end
 
   context "associations" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require_relative './concerns/receiver_spec'
 
 RSpec.describe User, type: :model do
   it_behaves_like "Wupee::Receiver"


### PR DESCRIPTION
Changes made:
1. Whenever a new notification type is created, a corresponding configuration object is created for every user. Just used a find_batch instead of looping through all the users. 
2. Whenever a new notification type is created  / whenever a new user is created, a configuration object is created for a user which always has the value as 'both' (means both email and notification) Changed this to a configurable thing,
